### PR TITLE
Checking seeds

### DIFF
--- a/data.py
+++ b/data.py
@@ -16,7 +16,6 @@ from torchvision.transforms import Compose, Normalize, Resize, ToTensor
 
 # Setting seeds for reproducibility
 np.random.seed(1693)
-# manual_seed(1693)
 
 
 class Data:
@@ -267,11 +266,12 @@ if __name__ == "__main__":
         num_users=20,
         writer=None,
         sample_ratio=0.5,
-        alpha=1,
+        alpha=0.001,
         normalize=True,
         visualize=True,
+        central=False
     )
-    print(sum([len(MNIST_data.train_data[i]) for i in range(MNIST_data.num_users)]))
+    print([len(MNIST_data.train_data[i]) for i in range(MNIST_data.num_users)])
 
     from collections import Counter
 

--- a/main.py
+++ b/main.py
@@ -353,7 +353,7 @@ if __name__ == "__main__":
                     args.decoder_epochs,
                 )
                 print(
-                    "Learning rate to for server decoder fine-tuning:",
+                    "Learning rate for server decoder fine-tuning:",
                     args.decoder_LR,
                 )
 


### PR DESCRIPTION
# Closes #44

This PR separates the random seeds used for dataset preparation/distribution across users and those used for model weights initialization to ensure we can run fair experiments for stability.

# Testing:
1. Pull down the most recent code.
2. Run `python3 main.py --algorithm fedavg --dataset mnist --num_users 10 --alpha 0.1 --sample_ratio 0.1 --glob_epochs 3 --local_epochs 1 --should_log 0 --seed 2021` and save the visualized heterogeneity plot.
3. Run `python3 main.py --algorithm fedavg --dataset mnist --num_users 10 --alpha 0.1 --sample_ratio 0.1 --glob_epochs 3 --local_epochs 1 --should_log 0 --seed 1588` and save the visualized heterogeneity plot.
4. Ensure the two plots are identical--this makes sure data is split the same way regardless of the seed inputted.
5. Check that the accuracies over time for the two runs is similar, but not the same. They should have slightly different learning curves given the different weight initializations.