### PR TITLE
Using SGD locally

### DIFF
--- a/data.py
+++ b/data.py
@@ -134,7 +134,11 @@ class Data:
         # Only partition into user datasets if we don't want centralized learning
         else:
             if self.alpha is None:
-                self.train_data = random_split(dataset_train, data_split_sequence, generator = torch.Generator().manual_seed(1693))
+                self.train_data = random_split(
+                    dataset_train,
+                    data_split_sequence,
+                    generator=torch.Generator().manual_seed(1693),
+                )
             else:
                 self.train_data = self.split_data_dirichlet(dataset_train, visualize)
 
@@ -269,7 +273,7 @@ if __name__ == "__main__":
         alpha=0.001,
         normalize=True,
         visualize=True,
-        central=False
+        central=False,
     )
     print([len(MNIST_data.train_data[i]) for i in range(MNIST_data.num_users)])
 

--- a/main.py
+++ b/main.py
@@ -220,7 +220,7 @@ if __name__ == "__main__":
         "--use_adam",
         type=int,
         default=0,
-        help="If 1, use Adam as the local optimized, else use SGD"
+        help="If 1, use Adam as the local optimized, else use SGD",
     )
 
     # Command line arguments for specific models

--- a/servers/server.py
+++ b/servers/server.py
@@ -47,7 +47,7 @@ class Server:
                     "num_channels": self.num_channels,
                     "num_classes": self.num_classes,
                     "local_LR": self.local_LR,
-                    "use_adam": self.use_adam
+                    "use_adam": self.use_adam,
                 }
             )
             self.users.append(new_user)

--- a/servers/server_fed_prox.py
+++ b/servers/server_fed_prox.py
@@ -27,7 +27,7 @@ class ServerFedProx(Server):
                     "num_channels": self.num_channels,
                     "num_classes": self.num_classes,
                     "local_LR": self.local_LR,
-                    "use_adam": self.use_adam
+                    "use_adam": self.use_adam,
                 },
                 self.mu,
             )

--- a/servers/server_fed_vae.py
+++ b/servers/server_fed_vae.py
@@ -119,7 +119,7 @@ class ServerFedVAE(Server):
                     "num_channels": self.num_channels,
                     "num_classes": self.num_classes,
                     "local_LR": self.local_LR,
-                    "use_adam": self.use_adam
+                    "use_adam": self.use_adam,
                 },
                 self.z_dim,
                 self.image_size,

--- a/servers/server_one_shot.py
+++ b/servers/server_one_shot.py
@@ -45,7 +45,7 @@ class ServerOneShot(Server):
                         "num_channels": self.num_channels,
                         "num_classes": self.num_classes,
                         "local_LR": self.local_LR,
-                        "use_adam": self.use_adam
+                        "use_adam": self.use_adam,
                     },
                     valid_dl,
                 )
@@ -59,7 +59,7 @@ class ServerOneShot(Server):
                         "num_channels": self.num_channels,
                         "num_classes": self.num_classes,
                         "local_LR": self.local_LR,
-                        "use_adam": self.use_adam
+                        "use_adam": self.use_adam,
                     },
                 )
             self.users.append(new_user)

--- a/users/user.py
+++ b/users/user.py
@@ -1,5 +1,5 @@
 from torch.nn import CrossEntropyLoss
-from torch.optim import Adam, SGD
+from torch.optim import SGD, Adam
 
 from models.classifier import Classifier
 

--- a/users/user_fed_vae.py
+++ b/users/user_fed_vae.py
@@ -1,6 +1,6 @@
 import copy
 
-from torch.optim import Adam, SGD
+from torch.optim import SGD, Adam
 
 from models.VAE import CVAE
 from users.user import User


### PR DESCRIPTION
# Closes #41 

This PR introduces the option for using SGD (with no momentum) as the local optimizer rather than Adam.

# TODO:
- [x] Check that ALL algorithms use the `use_adam` command line argument correctly and that ALL local optimizers are connected to this argument.

# Testing:
1. Pull down most recent code.
2. Run `python3 main.py --algorithm fedvae --dataset mnist --num_users 5 --alpha 1.0 --sample_ratio 0.1 --glob_epochs 5 --local_epochs 1 --should_log 0 --z_dim 50 --beta 1.0 --classifier_num_train_samples 1000 --classifier_epochs 1 --decoder_num_train_samples 1000  --decoder_epochs 1 --use_adam 1` and ensure there are no errors.
3. Run `python3 main.py --algorithm fedvae --dataset mnist --num_users 5 --alpha 1.0 --sample_ratio 0.1 --glob_epochs 5 --local_epochs 1 --should_log 0 --z_dim 50 --beta 1.0 --classifier_num_train_samples 1000 --classifier_epochs 1 --decoder_num_train_samples 1000  --decoder_epochs 1 --use_adam 0` and ensure there are no errors.
4. Quickly look through all of the user files and make sure that the `use_adam` actually changes the local optimizer.