### PR TITLE
Adding SVHN and CIFAR-10

### DIFF
--- a/data.py
+++ b/data.py
@@ -12,7 +12,7 @@ import torch
 import torchvision.utils
 from PIL import Image
 from torch.utils.data import Subset, random_split
-from torchvision.datasets import MNIST, FashionMNIST, SVHN, CIFAR10
+from torchvision.datasets import CIFAR10, MNIST, SVHN, FashionMNIST
 from torchvision.transforms import Compose, Normalize, Resize, ToTensor
 
 # Setting seeds for reproducibility
@@ -126,14 +126,14 @@ class Data:
             dataset_train = SVHN(
                 root="data/svhn",
                 download=True,
-                split='train',
+                split="train",
                 transform=transform_list,
             )
 
             dataset_test = SVHN(
                 root="data/svhn",
                 download=True,
-                split='test',
+                split="test",
                 transform=transform_list,
             )
         elif self.dataset_name == "cifar10":
@@ -221,7 +221,12 @@ class Data:
                     dataset_train.indices
                 ]  # case where we've subsetted the dataset, in which case we reframe indices based on this subset's data indices
             except AttributeError:
-                targets = np.array([int(dataset_train.dataset[i][1]) for i in range(len(dataset_train))]) # case where we have to manually extract targets
+                targets = np.array(
+                    [
+                        int(dataset_train.dataset[i][1])
+                        for i in range(len(dataset_train))
+                    ]
+                )  # case where we have to manually extract targets
 
         class_idxs = {}
 


### PR DESCRIPTION
Implementing SVHN and CIFAR-10 datasets as our candidate RGB datasets.

**Notes:**
- Results with SVHN are a little wonky... `FedAvg` gets stuck at 19.59% with perfectly homogeneous split (even when varying `num_users`), whereas the centralized training obtains nearly 80% accuracy --> probably not a concern, since increasing `sample_ratio` above 0.1 seems to fix this!
- Don't worry about seemingly low one-shot accuracy accuracy from `FedAvg`... need to increase local epochs for real experiments!